### PR TITLE
[Fix] 장애물 오브젝트 스프라이트 변경 및 콜라이더 조절

### DIFF
--- a/Assets/Character/Character.prefab
+++ b/Assets/Character/Character.prefab
@@ -175,7 +175,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hp: 3
-  jumpForce: 5
+  jumpForce: 7
   coinCount: 0
 --- !u!114 &4153138650986587388
 MonoBehaviour:
@@ -189,6 +189,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2279c0c38dfaf0e4f87fa93ec66af7d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  model: {fileID: 0}
+  currentText: {fileID: 0}
+  highScoreText: {fileID: 0}
+  gameOverText: {fileID: 0}
 --- !u!114 &1462107586493151584
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/RandomMap/TestObj_03.prefab
+++ b/Assets/RandomMap/TestObj_03.prefab
@@ -75,7 +75,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: ca5ce7f3f3ac3bb499d37119b1867d7e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 60e5d93de53da5642a38fce5925c3efa, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -120,7 +120,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 1.1875
+  m_Radius: 0.8
 --- !u!114 &2131540089984824741
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -287,7 +287,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 4872bd1108769a946a6acb68dc156fcf, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: iPhone
     m_Icons:


### PR DESCRIPTION
- 장애물 오브젝트의 콜라이더가 너무 커서 게임 진행에 밸런스적인 문제가 발생해서 콜라이더의 크기를 감소했습니다.
- 콜라이더 크기 감소에 맞게 스프라이트를 작은 장애물로 변경했습니다.